### PR TITLE
Fixing Github action build and test not running with PHP version < 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 #            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: 'v2.3.5'
-            composerversion: '2.3.5'
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 #            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: '2.3.2'
-            composerversion: '2.3.2'
+            vcomposerversion: 2
+            composerversion: 2
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Downgrading composer
       run: >
-        composer self-update --2.2
+        composer self-update --2.2.9
 
     - name: Install dependencies
       uses: php-actions/composer@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 #            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+            vcomposerversion: '2.3.2'
+            composerversion: '2.3.2'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 5.6
-            phpunit: 5
-            vcomposerversion: 'v2.2.9'
-            composerversion: '2.2.9'
           - php: '7.0'
             phpunit: 6
             vcomposerversion: 'v2.2.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,6 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.vcomposerversion }}
     - name: Run tests
       uses: php-actions/phpunit@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'
-            composerversion: '2.3.x'
+            composerversion: 2.3.x
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,27 @@ jobs:
     strategy:
       matrix:
         include:
+          - php: 5.6
+            phpunit: 5
+            composerversion: '2.2'
+          - php: '7.0'
+            phpunit: 6
+            composerversion: '2.2'
+          - php: 7.1
+            phpunit: 7
+            composerversion: '2.2'
           - php: 7.2
             phpunit: 8
+            composerversion: 'latest'
           - php: 7.3
             phpunit: 9
+            composerversion: 'latest'
           - php: 7.4
             phpunit: 9
+            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 
@@ -44,6 +57,7 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
+        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,13 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            composerversion: '2.2'
+            composerversion: '2.2.9'
           - php: '7.0'
             phpunit: 6
-            composerversion: '2.2'
+            composerversion: '2.2.9'
           - php: 7.1
             phpunit: 7
-            composerversion: '2.2'
+            composerversion: '2.2.9'
           - php: 7.2
             phpunit: 8
             composerversion: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: '2.1'
+            vcomposerversion: '1.x'
             composerversion: 'latest'
 #          - php: '7.0'
 #            phpunit: 6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 #            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: 2
-            composerversion: 2
+            vcomposerversion: '2.3.x'
+            composerversion: '2.3.x'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,13 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            composerversion: '2.2.9'
+            composerversion: 'v2.2.9'
           - php: '7.0'
             phpunit: 6
-            composerversion: '2.2.9'
+            composerversion: 'v2.2.9'
           - php: 7.1
             phpunit: 7
-            composerversion: '2.2.9'
+            composerversion: 'v2.2.9'
           - php: 7.2
             phpunit: 8
             composerversion: 'latest'
@@ -46,6 +46,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
+        tools: composer:${{ matrix.composerversion }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,32 +16,25 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: '2.1.9'
+            composerversion: '2.2.9'
+          - php: '7.0'
+            phpunit: 6
+            composerversion: '2.2.9'
+          - php: 7.1
+            phpunit: 7
+            composerversion: '2.2.9'
+          - php: 7.2
+            phpunit: 8
+            composerversion: '2.2.9'
+          - php: 7.3
+            phpunit: 9
             composerversion: 'latest'
-#          - php: '7.0'
-#            phpunit: 6
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.1
-#            phpunit: 7
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.2
-#            phpunit: 8
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.3
-#            phpunit: 9
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.4
-#            phpunit: 9
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: '8.0'
-#            phpunit: 9
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
+          - php: 7.4
+            phpunit: 9
+            composerversion: 'latest'
+          - php: '8.0'
+            phpunit: 9
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 
@@ -53,19 +46,13 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
-        tools: composer:${{ matrix.vcomposerversion }}
+        tools: composer:${{ matrix.composerversion }}
 
-#    - name: Cache Composer dependencies
-#      uses: actions/cache@v2
-#      with:
-#        path: /tmp/composer-cache
-#        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
-
-#    - name: Install dependencies
-#      uses: php-actions/composer@v6
-#      with:
-#        php_version: ${{ matrix.php }}
-#        version: ${{ matrix.vcomposerversion }}
+    - name: Cache Composer dependencies
+      uses: actions/cache@v2
+      with:
+        path: /tmp/composer-cache
+        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: '2.2.9'
+            vcomposerversion: 'latest'
             composerversion: 'latest'
 #          - php: '7.0'
 #            phpunit: 6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: 'latest'
+            vcomposerversion: '2.2.9'
             composerversion: 'latest'
 #          - php: '7.0'
 #            phpunit: 6
@@ -66,6 +66,7 @@ jobs:
       with:
         php_version: ${{ matrix.php }}
         version: ${{ matrix.vcomposerversion }}
+        composer_version: ${{ matrix.vcomposerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - php: 5.6
+            phpunit: 5
+            vcomposerversion: 'v2.2.6'
+            composerversion: '2.2.6'
           - php: '7.0'
             phpunit: 6
             vcomposerversion: 'v2.2.6'
@@ -58,13 +62,13 @@ jobs:
         key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
-      uses: php-actions/composer@v5
+      uses: php-actions/composer@v6
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.vcomposerversion }}
+        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3
       with:
         php_version: ${{ matrix.php }}
-       version: ${{ matrix.phpunit }}
+        version: ${{ matrix.phpunit }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
 #            phpunit: 5
 #            vcomposerversion: '2.2.9'
 #            composerversion: 'latest'
-          - php: '7.0'
-            phpunit: 6
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: 7.1
-            phpunit: 7
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
+#          - php: '7.0'
+#            phpunit: 6
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.1
+#            phpunit: 7
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
           - php: 7.2
             phpunit: 8
             vcomposerversion: '2.2.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,11 +61,17 @@ jobs:
 #        path: /tmp/composer-cache
 #        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
+#    - name: Install dependencies
+#      uses: php-actions/composer@v6
+#      with:
+#        php_version: ${{ matrix.php }}
+#        version: ${{ matrix.vcomposerversion }}
+
     - name: Install dependencies
-      uses: php-actions/composer@v6
-      with:
-        php_version: ${{ matrix.php }}
-        version: ${{ matrix.vcomposerversion }}
+      run: |
+        composer --no-plugins --no-scripts install
+        composer --no-plugins --no-scripts dump-autoload -o
+        vendor/bin/phpunit --configuration ./phpunit.xml --teamcity
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,30 +14,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '7.0'
-            phpunit: 6
-            vcomposerversion: 'v2.2.9'
-            composerversion: '2.2.9'
-          - php: 7.1
-            phpunit: 7
-            vcomposerversion: 'v2.2.9'
-            composerversion: '2.2.9'
-          - php: 7.2
-            phpunit: 8
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
-          - php: 7.3
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
-          - php: 7.4
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+#          - php: '7.0'
+#            phpunit: 6
+#            vcomposerversion: 'v2.2.9'
+#            composerversion: '2.2.9'
+#          - php: 7.1
+#            phpunit: 7
+#            vcomposerversion: 'v2.2.9'
+#            composerversion: '2.2.9'
+#          - php: 7.2
+#            phpunit: 8
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
+#          - php: 7.3
+#            phpunit: 9
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
+#          - php: 7.4
+#            phpunit: 9
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+            vcomposerversion: 'v2.3.5'
+            composerversion: '2.3.5'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'
-            composerversion: '2.3.5'
+            composerversion: 5
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,32 +16,32 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: 'v2.2.6'
-            composerversion: '2.2.6'
-          - php: '7.0'
-            phpunit: 6
-            vcomposerversion: 'v2.2.6'
-            composerversion: '2.2.6'
-          - php: 7.1
-            phpunit: 7
-            vcomposerversion: 'v2.2.6'
-            composerversion: '2.2.6'
-          - php: 7.2
-            phpunit: 8
             vcomposerversion: 'latest'
             composerversion: 'latest'
-          - php: 7.3
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
-          - php: 7.4
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
-          - php: '8.0'
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+#          - php: '7.0'
+#            phpunit: 6
+#            vcomposerversion: 'v2.2.9'
+#            composerversion: '2.2.9'
+#          - php: 7.1
+#            phpunit: 7
+#            vcomposerversion: 'v2.2.9'
+#            composerversion: '2.2.9'
+#          - php: 7.2
+#            phpunit: 8
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
+#          - php: 7.3
+#            phpunit: 9
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
+#          - php: 7.4
+#            phpunit: 9
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
+#          - php: '8.0'
+#            phpunit: 9
+#            vcomposerversion: 'latest'
+#            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,24 +16,31 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            composerversion: 'v2.2.9'
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
           - php: '7.0'
             phpunit: 6
-            composerversion: 'v2.2.9'
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
           - php: 7.1
             phpunit: 7
-            composerversion: 'v2.2.9'
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
           - php: 7.2
             phpunit: 8
+            vcomposerversion: 'latest'
             composerversion: 'latest'
           - php: 7.3
             phpunit: 9
+            vcomposerversion: 'latest'
             composerversion: 'latest'
           - php: 7.4
             phpunit: 9
+            vcomposerversion: 'latest'
             composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
+            vcomposerversion: 'latest'
             composerversion: 'latest'
 
     runs-on: ubuntu-latest
@@ -46,7 +53,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
-        tools: composer:${{ matrix.composerversion }}
+        tools: composer:${{ matrix.vcomposerversion }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v2
@@ -58,6 +65,7 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
+        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 5.6
-            phpunit: 5
-            composerversion: 'v2.2.9'
-          - php: '7.0'
-            phpunit: 6
-            composerversion: 'v2.2.9'
-          - php: 7.1
-            phpunit: 7
-            composerversion: 'v2.2.9'
           - php: 7.2
             phpunit: 8
             composerversion: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,11 @@ jobs:
 #        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
-      uses: php-actions/composer@v5
+      uses: php-actions/composer@v6
       with:
         php_version: ${{ matrix.php }}
+        version: ${{ matrix.vcomposerversion }}
+
     - name: Run tests
       uses: php-actions/phpunit@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,15 @@ jobs:
     strategy:
       matrix:
         include:
+          - php: 5.6
+            phpunit: 5
+            composerversion: 'v2.2.9'
+          - php: '7.0'
+            phpunit: 6
+            composerversion: 'v2.2.9'
+          - php: 7.1
+            phpunit: 7
+            composerversion: 'v2.2.9'
           - php: 7.2
             phpunit: 8
             composerversion: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,30 +18,30 @@ jobs:
             phpunit: 5
             vcomposerversion: '2.2.9'
             composerversion: 'latest'
-          - php: '7.0'
-            phpunit: 6
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: 7.1
-            phpunit: 7
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: 7.2
-            phpunit: 8
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: 7.3
-            phpunit: 9
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: 7.4
-            phpunit: 9
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
-          - php: '8.0'
-            phpunit: 9
-            vcomposerversion: '2.2.9'
-            composerversion: 'latest'
+#          - php: '7.0'
+#            phpunit: 6
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.1
+#            phpunit: 7
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.2
+#            phpunit: 8
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.3
+#            phpunit: 9
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.4
+#            phpunit: 9
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: '8.0'
+#            phpunit: 9
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'
-            composerversion: 2.3.5
+            composerversion: '2.3.5'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           - php: '7.0'
             phpunit: 6
-            vcomposerversion: 'v2.2.9'
+            vcomposerversion: 'v2.2.6'
             composerversion: '2.2.9'
           - php: 7.1
             phpunit: 7
-            vcomposerversion: 'v2.2.9'
+            vcomposerversion: 'v2.2.6'
             composerversion: '2.2.9'
           - php: 7.2
             phpunit: 8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: '1.x'
+            vcomposerversion: '2.1.9'
             composerversion: 'latest'
 #          - php: '7.0'
 #            phpunit: 6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
 #            phpunit: 8
 #            vcomposerversion: '2.2.9'
 #            composerversion: 'latest'
-#          - php: 7.3
-#            phpunit: 9
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
+          - php: 7.3
+            phpunit: 9
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
           - php: 7.4
             phpunit: 9
             vcomposerversion: '2.2.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '7.0'
-            phpunit: 6
-            vcomposerversion: 'v2.2.6'
-            composerversion: '2.2.9'
-          - php: 7.1
-            phpunit: 7
-            vcomposerversion: 'v2.2.6'
-            composerversion: '2.2.9'
-          - php: 7.2
-            phpunit: 8
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
           - php: 7.3
             phpunit: 9
             vcomposerversion: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
-        tools: composer:${{ matrix.vcomposerversion }}
+#        tools: composer:${{ matrix.vcomposerversion }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v2
@@ -61,7 +61,7 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.composerversion }}
+#        version: ${{ matrix.composerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'
-            composerversion: 2.3.x
+            composerversion: 1
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
-#        tools: composer:${{ matrix.vcomposerversion }}
+        tools: composer:${{ matrix.vcomposerversion }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v2
@@ -61,10 +61,10 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-#        version: ${{ matrix.composerversion }}
+        version: ${{ matrix.vcomposerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3
       with:
         php_version: ${{ matrix.php }}
-        version: ${{ matrix.phpunit }}
+       version: ${{ matrix.phpunit }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,10 @@ jobs:
         path: /tmp/composer-cache
         key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
+    - name: Downgrading composer
+      run: >
+        composer self-update --2.2
+
     - name: Install dependencies
       uses: php-actions/composer@v6
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,26 +14,26 @@ jobs:
     strategy:
       matrix:
         include:
-#          - php: '7.0'
-#            phpunit: 6
-#            vcomposerversion: 'v2.2.9'
-#            composerversion: '2.2.9'
-#          - php: 7.1
-#            phpunit: 7
-#            vcomposerversion: 'v2.2.9'
-#            composerversion: '2.2.9'
-#          - php: 7.2
-#            phpunit: 8
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
-#          - php: 7.3
-#            phpunit: 9
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
-#          - php: 7.4
-#            phpunit: 9
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
+          - php: '7.0'
+            phpunit: 6
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
+          - php: 7.1
+            phpunit: 7
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
+          - php: 7.2
+            phpunit: 8
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
+          - php: 7.3
+            phpunit: 9
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
+          - php: 7.4
+            phpunit: 9
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '8.0'
             phpunit: 9
             vcomposerversion: '2.3.x'
-            composerversion: 1
+            composerversion: 2.3.5
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
         include:
           - php: '7.0'
             phpunit: 6
-            vcomposerversion: 'v2.2.9'
-            composerversion: '2.2.9'
+            vcomposerversion: 'v2.2.6'
+            composerversion: '2.2.6'
           - php: 7.1
             phpunit: 7
-            vcomposerversion: 'v2.2.9'
-            composerversion: '2.2.9'
+            vcomposerversion: 'v2.2.6'
+            composerversion: '2.2.6'
           - php: 7.2
             phpunit: 8
             vcomposerversion: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: '2.2.9'
+            vcomposerversion: '2.1'
             composerversion: 'latest'
 #          - php: '7.0'
 #            phpunit: 6
@@ -66,7 +66,6 @@ jobs:
       with:
         php_version: ${{ matrix.php }}
         version: ${{ matrix.vcomposerversion }}
-        composer_version: ${{ matrix.vcomposerversion }}
 
     - name: Run tests
       uses: php-actions/phpunit@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,34 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 7.3
-            phpunit: 9
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+#          - php: 5.6
+#            phpunit: 5
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: '7.0'
+#            phpunit: 6
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.1
+#            phpunit: 7
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.2
+#            phpunit: 8
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
+#          - php: 7.3
+#            phpunit: 9
+#            vcomposerversion: '2.2.9'
+#            composerversion: 'latest'
           - php: 7.4
             phpunit: 9
-            vcomposerversion: 'latest'
+            vcomposerversion: '2.2.9'
             composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
-            vcomposerversion: '2.3.x'
-            composerversion: 5
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 
@@ -49,7 +65,7 @@ jobs:
       uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
-
+        version: ${{ matrix.vcomposerversion }}
     - name: Run tests
       uses: php-actions/phpunit@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 5.6
-            phpunit: 5
-          - php: '7.0'
-            phpunit: 6
-          - php: 7.1
-            phpunit: 7
           - php: 7.2
             phpunit: 8
           - php: 7.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,18 +18,18 @@ jobs:
 #            phpunit: 5
 #            vcomposerversion: '2.2.9'
 #            composerversion: 'latest'
-#          - php: '7.0'
-#            phpunit: 6
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.1
-#            phpunit: 7
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.2
-#            phpunit: 8
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
+          - php: '7.0'
+            phpunit: 6
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
+          - php: 7.1
+            phpunit: 7
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
+          - php: 7.2
+            phpunit: 8
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
           - php: 7.3
             phpunit: 9
             vcomposerversion: '2.2.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
-            vcomposerversion: 'latest'
-            composerversion: 'latest'
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
 #          - php: '7.0'
 #            phpunit: 6
 #            vcomposerversion: 'v2.2.9'
@@ -66,7 +66,7 @@ jobs:
         composer self-update --2.2
 
     - name: Install dependencies
-      uses: php-actions/composer@v6
+      uses: php-actions/composer@v5
       with:
         php_version: ${{ matrix.php }}
         version: ${{ matrix.composerversion }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,11 @@ jobs:
         coverage: none
         tools: composer:${{ matrix.vcomposerversion }}
 
-    - name: Cache Composer dependencies
-      uses: actions/cache@v2
-      with:
-        path: /tmp/composer-cache
-        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+#    - name: Cache Composer dependencies
+#      uses: actions/cache@v2
+#      with:
+#        path: /tmp/composer-cache
+#        key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
       uses: php-actions/composer@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,34 +14,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 5.6
-            phpunit: 5
+          - php: '7.0'
+            phpunit: 6
             vcomposerversion: 'v2.2.9'
             composerversion: '2.2.9'
-#          - php: '7.0'
-#            phpunit: 6
-#            vcomposerversion: 'v2.2.9'
-#            composerversion: '2.2.9'
-#          - php: 7.1
-#            phpunit: 7
-#            vcomposerversion: 'v2.2.9'
-#            composerversion: '2.2.9'
-#          - php: 7.2
-#            phpunit: 8
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
-#          - php: 7.3
-#            phpunit: 9
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
-#          - php: 7.4
-#            phpunit: 9
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
-#          - php: '8.0'
-#            phpunit: 9
-#            vcomposerversion: 'latest'
-#            composerversion: 'latest'
+          - php: 7.1
+            phpunit: 7
+            vcomposerversion: 'v2.2.9'
+            composerversion: '2.2.9'
+          - php: 7.2
+            phpunit: 8
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
+          - php: 7.3
+            phpunit: 9
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
+          - php: 7.4
+            phpunit: 9
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
+          - php: '8.0'
+            phpunit: 9
+            vcomposerversion: 'latest'
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 
@@ -60,10 +56,6 @@ jobs:
       with:
         path: /tmp/composer-cache
         key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
-
-    - name: Downgrading composer
-      run: >
-        composer self-update --2.2.9
 
     - name: Install dependencies
       uses: php-actions/composer@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,18 @@ jobs:
     strategy:
       matrix:
         include:
-#          - php: 5.6
-#            phpunit: 5
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: '7.0'
-#            phpunit: 6
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
-#          - php: 7.1
-#            phpunit: 7
-#            vcomposerversion: '2.2.9'
-#            composerversion: 'latest'
+          - php: 5.6
+            phpunit: 5
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
+          - php: '7.0'
+            phpunit: 6
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
+          - php: 7.1
+            phpunit: 7
+            vcomposerversion: '2.2.9'
+            composerversion: 'latest'
           - php: 7.2
             phpunit: 8
             vcomposerversion: '2.2.9'


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests
Fixing actions, not required 

#### Link to issue/feature request: [Link](https://github.com/Mastercard/client-encryption-php/issues/19)

#### Description
PHP build runs against the latest version of composer. The lastest version of composer no longer works with PHP < 7.2. This build will have an earlier version of composer work with those PHP versions
