### PR TITLE
[Bug] Fixing Github action build and test not running with PHP version < 7.2 #20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,25 @@ jobs:
         include:
           - php: 5.6
             phpunit: 5
+            composerversion: '2.2.9'
           - php: '7.0'
             phpunit: 6
+            composerversion: '2.2.9'
           - php: 7.1
             phpunit: 7
+            composerversion: '2.2.9'
           - php: 7.2
             phpunit: 8
+            composerversion: '2.2.9'
           - php: 7.3
             phpunit: 9
+            composerversion: 'latest'
           - php: 7.4
             phpunit: 9
+            composerversion: 'latest'
           - php: '8.0'
             phpunit: 9
+            composerversion: 'latest'
 
     runs-on: ubuntu-latest
 
@@ -39,6 +46,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         coverage: none
+        tools: composer:${{ matrix.composerversion }}
 
     - name: Cache Composer dependencies
       uses: actions/cache@v2
@@ -47,9 +55,10 @@ jobs:
         key: php${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
-      uses: php-actions/composer@v5
-      with:
-        php_version: ${{ matrix.php }}
+      run: |
+        composer --no-plugins --no-scripts install
+        composer --no-plugins --no-scripts dump-autoload -o
+        vendor/bin/phpunit --configuration ./phpunit.xml --teamcity
 
     - name: Run tests
       uses: php-actions/phpunit@v3


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests
Fixing actions, not required 

#### Link to issue/feature request: [Link](https://github.com/Mastercard/client-encryption-php/issues/19)

#### Description
PHP build runs against the latest version of composer. The lastest version of composer no longer works with PHP < 7.2. This build will have an earlier version of composer work with those PHP versions